### PR TITLE
It adds support non ascii chars at table name

### DIFF
--- a/lib/ex_airtable/table_cache.ex
+++ b/lib/ex_airtable/table_cache.ex
@@ -130,7 +130,7 @@ defmodule ExAirtable.TableCache do
   def table_for(table_module) do
     (table_module.base().id <> table_module.name())
     |> String.downcase()
-    |> String.replace(~r/\W/, "")
+    |> String.replace(~r/\W/u, "")
     |> String.to_atom()
   end
 


### PR DESCRIPTION
We use Cyrillic table name and this regex broke it. 
I adds unicode support to this regex