### PR TITLE
Non-controversial reformat of code to remove extraneous spaces, etc

### DIFF
--- a/lib/ex_airtable.ex
+++ b/lib/ex_airtable.ex
@@ -67,14 +67,14 @@ defmodule ExAirtable do
 
         # ...
       end
-      
-  Note that the `:sync_rate` (the rate at which tables are refreshed from Airtable) is optional and will default to 30 seconds if omitted. 
+
+  Note that the `:sync_rate` (the rate at which tables are refreshed from Airtable) is optional and will default to 30 seconds if omitted.
 
   Once you have configured things this way, you can call `ExAirtable` directly, and get all of the speed and reliability benefits of caching and rate-limiting.
 
       iex> ExAirtable.list(MyApp.MyAirtable)
       {:ok, %ExAirtable.Airtable.List{}}
-      
+
       iex> ExAirtable.retrieve(MyApp.MyAirtable, "rec12345")
       {:ok, %ExAirtable.Airtable.Record{}}
 
@@ -83,7 +83,7 @@ defmodule ExAirtable do
   The codebase includes an example `Table` (`ExAirtable.Example.EnvTable`) that you can use to play around and get an idea of how the system works. This module uses environment variables as configuration. The included `Makefile` provides some quick command-line tools to run tests and a console with those environment variables pre-loaded. Simply edit the relevant environment variables in `Makefile` to point to a valid base/table name, and you'll be able to interact directly like this:
 
       # first, run `make console`, then...
-     
+
       # retrieve data directly from Airtable's API...
       iex> EnvTable.list
       %ExAirtable.Airtable.List{records: [%Record{}, %Record{}, ...]}
@@ -91,15 +91,15 @@ defmodule ExAirtable do
       iex> EnvTable.retrieve("rec12345")
       %ExAirtable.Airtable.Record{}
 
-      # start a caching and rate-limiting server 
+      # start a caching and rate-limiting server
       iex> ExAirtable.Supervisor.start_link([EnvTable])
 
       # get all records from the cache (without hitting the Airtable API)
       iex> ExAirtable.list(EnvTable)
       %ExAirtable.Airtable.List{}
-      
+
   ## Convenience Methods
-      
+
   Because certain tasks such as retrieving fields and finding related data happen so often, we put in a few convenience functions to make those jobs easier.
 
       # grab a field from a record
@@ -110,22 +110,22 @@ defmodule ExAirtable do
       # (ie find all records in `list` where `"Users"` matches `"rec1234"`)
       iex> ExAirtable.Airtable.List.filter_relations(list, "Users", "rec1234")
       [%Record{fields: %{"Users" => ["rec1234", "rec3456"]}}, ...]
-      
+
       # convert Airtable field names into local field names
       defmodule MyTable do
         use ExAirtable
-        
+
         def schema do
           %{"AirtableField" => "localfield"}
         end
       end
-      
+
       iex> record = %ExAirtable.Airtable.Record{id: "1", fields: %{"AirtableField" => "value"}}
-      
+
       iex> MyTable.to_schema(record)
-      %{"airtable_id" => "1", "localfield" => "value"} 
+      %{"airtable_id" => "1", "localfield" => "value"}
       # 👆 handy for ecto schema conversion
-      
+
   See the `ExAirtable.Airtable.List` and `ExAirtable.Airtable.Record` module documentation for more information about field, list, and schema retrieval, filtering and conversion.
   """
 
@@ -133,7 +133,7 @@ defmodule ExAirtable do
   alias ExAirtable.RateLimiter.Request
 
   @doc """
-  Create one or more records in your Airtable from an %Airtable.List{} request. 
+  Create one or more records in your Airtable from an %Airtable.List{} request.
 
   If your list includes more than 10 records, the request will be split so as not to be rejected by the Airtable API.
 
@@ -157,7 +157,7 @@ defmodule ExAirtable do
   end
 
   @doc """
-  Delete a single record (by ID) from an Airtable. 
+  Delete a single record (by ID) from an Airtable.
 
   If successful, the record will be deleted from the cache as well.
 
@@ -214,7 +214,7 @@ defmodule ExAirtable do
   end
 
   @doc """
-  Update a record in your Airtable. 
+  Update a record in your Airtable.
 
   This call is asynchronous, but the local cache will be automatically updated when the callback is successful.
 

--- a/lib/ex_airtable/airtable/list.ex
+++ b/lib/ex_airtable/airtable/list.ex
@@ -1,6 +1,6 @@
 defmodule ExAirtable.Airtable.List do
   @moduledoc """
-  Struct for an Airtable List of Records. 
+  Struct for an Airtable List of Records.
 
   This should directly match results being sent/returned from the Airtable REST API.
   """
@@ -17,7 +17,7 @@ defmodule ExAirtable.Airtable.List do
         }
 
   @doc """
-  Convert a typical Airtable JSON response into an %ExAirtable.Airtable.List{}. 
+  Convert a typical Airtable JSON response into an %ExAirtable.Airtable.List{}.
 
   Any weird response will return an empty list.
   """
@@ -31,7 +31,7 @@ defmodule ExAirtable.Airtable.List do
   def from_map(_other), do: %__MODULE__{}
 
   @doc """
-  Filter the records in a list by a given function. 
+  Filter the records in a list by a given function.
 
   Returns an array of `%ExAirtable.Airtable.Record{}` structs.
 

--- a/lib/ex_airtable/airtable/record.ex
+++ b/lib/ex_airtable/airtable/record.ex
@@ -37,25 +37,28 @@ defmodule ExAirtable.Airtable.Record do
   This is essentially the reverse of `to_schema/2`.
   """
   def from_schema(table_module, attrs) when is_atom(table_module) and is_map(attrs) do
-    reverse_schema = case apply(table_module, :schema, []) do
-      nil ->
-        Enum.reduce(attrs, %{}, fn {k, _v}, acc -> 
-          if k == "airtable_id" || k == "inserted_at" do
-            acc
-          else
-            Map.put(acc, k, k) 
-          end
-        end)
-      schema ->
-        Enum.reduce(schema, %{}, fn {k, v}, acc -> Map.put(acc, v, k) end)
-    end
+    reverse_schema =
+      case apply(table_module, :schema, []) do
+        nil ->
+          Enum.reduce(attrs, %{}, fn {k, _v}, acc ->
+            if k == "airtable_id" || k == "inserted_at" do
+              acc
+            else
+              Map.put(acc, k, k)
+            end
+          end)
 
-    fields = Enum.reduce(attrs, %{}, fn {k, v}, acc ->
-      case Map.get(reverse_schema, k) do
-        nil -> acc
-        airtable_key -> Map.put(acc, airtable_key, v)
+        schema ->
+          Enum.reduce(schema, %{}, fn {k, v}, acc -> Map.put(acc, v, k) end)
       end
-    end)
+
+    fields =
+      Enum.reduce(attrs, %{}, fn {k, v}, acc ->
+        case Map.get(reverse_schema, k) do
+          nil -> acc
+          airtable_key -> Map.put(acc, airtable_key, v)
+        end
+      end)
 
     %__MODULE__{
       fields: fields,
@@ -109,9 +112,11 @@ defmodule ExAirtable.Airtable.Record do
       end)
 
     case is_binary(Enum.at(Map.keys(schema), 0)) do
-      true -> Map.merge(schema, %{"airtable_id" => record.id, "inserted_at" => record.createdTime})
-      false -> Map.merge(schema, %{airtable_id: record.id, inserted_at: record.createdTime})
+      true ->
+        Map.merge(schema, %{"airtable_id" => record.id, "inserted_at" => record.createdTime})
+
+      false ->
+        Map.merge(schema, %{airtable_id: record.id, inserted_at: record.createdTime})
     end
   end
-
 end

--- a/lib/ex_airtable/config/base.ex
+++ b/lib/ex_airtable/config/base.ex
@@ -1,6 +1,6 @@
 defmodule ExAirtable.Config.Base do
   @moduledoc """
-  Configuration struct for an Airtable "base". 
+  Configuration struct for an Airtable "base".
 
   This is extracted into a separate type/module so that it can be more easily centrlized in systems that implement multiple tables / bases.
   """

--- a/lib/ex_airtable/rate_limiter/request.ex
+++ b/lib/ex_airtable/rate_limiter/request.ex
@@ -1,6 +1,6 @@
 defmodule ExAirtable.RateLimiter.Request do
   @moduledoc """
-  The RateLimiter takes an `%ExAirtable.RateLimiter.Request{}`, runs its `:job` and (optionally) sends the results to the `:callback` function as arguments. 
+  The RateLimiter takes an `%ExAirtable.RateLimiter.Request{}`, runs its `:job` and (optionally) sends the results to the `:callback` function as arguments.
 
   Any arguments defined in the `:callback` `%Job{}` will be prepended to the function arguments, with the results of `:job` being the final argument passed.
   """

--- a/lib/ex_airtable/service.ex
+++ b/lib/ex_airtable/service.ex
@@ -1,6 +1,6 @@
 defmodule ExAirtable.Service do
   @moduledoc """
-  The `Service` defines methods to directly hit the Airtable API. 
+  The `Service` defines methods to directly hit the Airtable API.
 
   Most methods take an `Airtable.Config.Table{}`, along with parameters to be forwarded to the REST API.
 
@@ -9,14 +9,14 @@ defmodule ExAirtable.Service do
   API results will be returned in `ExAirtable.Airtable.List{}` and `ExAirtable.Airtable.Record{}` structs, to match what the Airtable API returns.
 
   ## Examples
-    
+
       iex> table = %ExAirtable.Config.Table{
         base: %ExAirtable.Config.Base{
           id: "your base ID",
           api_key: "your api key"
         },
         name: "My Airtable Table Name"
-      } 
+      }
       iex> list(table)
       %Airtable.List{}
 
@@ -29,7 +29,7 @@ defmodule ExAirtable.Service do
   alias ExAirtable.{Airtable, Config}
 
   @doc """
-  Create a record in Airtable. Pass in a valid `%ExAirtable.Airtable.List{}` struct. 
+  Create a record in Airtable. Pass in a valid `%ExAirtable.Airtable.List{}` struct.
 
   Returns an `%ExAirtable.Airtable.List{}` on success.
 
@@ -57,7 +57,7 @@ defmodule ExAirtable.Service do
   Returns a custom map on success - see below.
 
   ## Example
-      
+
       iex> delete(table, "recJmmAR0IzpaekBn")
       %{"deleted" => true, "id" => "recJmmAR0IzpaekBn"}
   """
@@ -85,7 +85,7 @@ defmodule ExAirtable.Service do
   end
 
   @doc """
-  Similar to `list/2`, except results aren't automatically concatenated with multiple API requests. 
+  Similar to `list/2`, except results aren't automatically concatenated with multiple API requests.
 
   This is typically utilized by cache processes rather than called by hand - although it could be used by hand if you only want one page of results.
   """
@@ -95,7 +95,7 @@ defmodule ExAirtable.Service do
   end
 
   @doc """
-  Retrieve a single record, matching by ID. 
+  Retrieve a single record, matching by ID.
 
   Returns an `%Airtable.Record{}` on success and an `{:error, reason}` tuple on failure.
   """

--- a/lib/ex_airtable/supervisor.ex
+++ b/lib/ex_airtable/supervisor.ex
@@ -1,6 +1,6 @@
 defmodule ExAirtable.Supervisor do
   @moduledoc """
-  This is the "master control" that takes care of rate-limiting and caching for all of your Tables. 
+  This is the "master control" that takes care of rate-limiting and caching for all of your Tables.
 
   See the `ExAirtable` module and `start_link/2` for details about initialization.
   """

--- a/lib/ex_airtable/table.ex
+++ b/lib/ex_airtable/table.ex
@@ -1,6 +1,6 @@
 defmodule ExAirtable.Table do
   @moduledoc """
-  The `Table` behaviour allows you to define your own modules that use Airtables. 
+  The `Table` behaviour allows you to define your own modules that use Airtables.
 
   It is a thin wrapper around `Service`, but often more convenient to use.
 
@@ -17,10 +17,10 @@ defmodule ExAirtable.Table do
       end
 
       iex> MyTable.list()
-      %ExAirtable.Airtable.List{} 
+      %ExAirtable.Airtable.List{}
 
       iex> MyTable.retrieve("rec123")
-      %ExAirtable.Airtable.Record{} 
+      %ExAirtable.Airtable.Record{}
   """
 
   alias ExAirtable.{Airtable, Config, Service}
@@ -156,7 +156,7 @@ defmodule ExAirtable.Table do
 
       @doc """
       Similar to `list/1`, except results aren't automatically concatenated
-      with multiple API requests. 
+      with multiple API requests.
 
       Typically called automatically by a TableSynchronizer process.
       """
@@ -172,7 +172,7 @@ defmodule ExAirtable.Table do
       defoverridable list_params: 0
 
       @doc """
-      Get a single record from your Airtable, matching by ID. 
+      Get a single record from your Airtable, matching by ID.
 
       See `Service.retrieve/2` for details.
       """

--- a/lib/ex_airtable/table_cache.ex
+++ b/lib/ex_airtable/table_cache.ex
@@ -1,11 +1,11 @@
 defmodule ExAirtable.TableCache do
   @moduledoc """
-  A caching server for an `ExAirtable.Table`. 
+  A caching server for an `ExAirtable.Table`.
 
   Given a module name that implements the `Table` behaviour, it will automatically spawn synchronization processes and provide an in-memory data store that stays in sync with the external Airtable table/base.
 
   ## Examples
-      
+
       iex> TableCache.retrieve(MyAirtableTable, "rec1234")
       %Airtable.Record{}
 
@@ -35,7 +35,7 @@ defmodule ExAirtable.TableCache do
   #
 
   @doc """
-  Given an `ExAirtable.Table` module and an ID map, delete the record matching that ID. 
+  Given an `ExAirtable.Table` module and an ID map, delete the record matching that ID.
 
   This is an asynchronous operation.
   """
@@ -142,7 +142,7 @@ defmodule ExAirtable.TableCache do
   end
 
   #
-  # GENSERVER 
+  # GENSERVER
   #
 
   @impl GenServer

--- a/lib/ex_airtable/table_synchronizer.ex
+++ b/lib/ex_airtable/table_synchronizer.ex
@@ -1,8 +1,8 @@
 defmodule ExAirtable.TableSynchronizer do
   @moduledoc """
-  Run scheduled synchronization of an `ExAirtable.TableCache` against the relevant Airtable base. 
+  Run scheduled synchronization of an `ExAirtable.TableCache` against the relevant Airtable base.
 
-  This will be automatically spawned and linked to an `ExAirtable.TableCache` when `start_link/2` is run for that cache.  
+  This will be automatically spawned and linked to an `ExAirtable.TableCache` when `start_link/2` is run for that cache.
   """
 
   defstruct sync_rate: nil, table_module: nil


### PR DESCRIPTION
Noncontroversial re-formatting of code that mostly removes extraneous spaces at the end of lines, but also makes the formatting of the `Record` module consistent with the rest of the code base.

The intent here is not to nit-pick but to make it easier to read code changes in repo forks that are often obscured by the reformatting of the code base. These changes are consistent with the latest version of the Elixir formatter.